### PR TITLE
Fix the number of MWL stars for higher MWL tiers.

### DIFF
--- a/formatting.js
+++ b/formatting.js
@@ -283,7 +283,7 @@ module.exports.formatCards = (cards, missing) => {
             a.pretext += influenceDots(cards[i].factioncost);
         }
         if (cards[i].mwl) {
-            a.pretext += '☆';
+            a.pretext += '☆'.repeat(cards[i].mwl);
         }
         a.pretext += '\n';
         var first = true;


### PR DESCRIPTION
MWL 1.2 introduced different tiers (https://images-cdn.fantasyflightgames.com/filer_public/fa/84/fa84c620-cd7e-4c6c-96bd-c703419fca5e/adn_mwl_v12_web.pdf). The NRDB already reflects that. This PR fixes the number of stars to match the MWL tiers from the NRDB API.